### PR TITLE
Expose frame connection for testing/instrumenting purposes.

### DIFF
--- a/src/Network/HTTP2/Client/FrameConnection.hs
+++ b/src/Network/HTTP2/Client/FrameConnection.hs
@@ -3,9 +3,10 @@
 {-# LANGUAGE RankNTypes  #-}
 
 module Network.HTTP2.Client.FrameConnection (
-      Http2FrameConnection
+      Http2FrameConnection(..)
     , newHttp2FrameConnection
     -- * Interact at the Frame level.
+    , Http2ServerStream(..)
     , Http2FrameClientStream(..)
     , makeFrameClientStream
     , sendOne

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,11 @@
+import Network.HTTP2.Client
+import Network.HTTP2.Client.FrameConnection
+
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = do
+    -- only demonstrates test-client setup
+    let serverstream = Http2ServerStream undefined
+    let makeframestream sid = Http2FrameClientStream (print . fmap snd) sid
+    let fakeFrameConn = Http2FrameConnection makeframestream serverstream undefined
+    _ <- wrapFrameClient fakeFrameConn 2048 2048 []
+    putStrLn "OK"


### PR DESCRIPTION
Closes #5 .

Also cleanup the commented and hard-to-follow 'tutorial'.