### PR TITLE
Throw on goaways

### DIFF
--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -25,6 +25,7 @@ module Network.HTTP2.Client (
     , IncomingFlowControl(..)
     , OutgoingFlowControl(..)
     -- * Exceptions
+    , RemoteSentGoAwayFrame(..)
     , linkHttp2Client
     -- * Misc.
     , FlagSetter

--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -53,6 +53,7 @@ import           Network.HPACK as HPACK
 import           Network.HTTP2 as HTTP2
 import           Network.Socket (HostName, PortNumber)
 import           Network.TLS (ClientParams)
+import           System.IO (hPutStrLn, stderr)
 
 import           Network.HTTP2.Client.FrameConnection
 
@@ -555,7 +556,7 @@ incomingControlFramesLoop frames settings hpackEncoder ackPing ackSettings = for
         (GoAwayFrame lastSid errCode reason)  ->
              throwIO $ RemoteSentGoAwayFrame lastSid errCode reason
 
-        _                   -> putStrLn ("UNHANDLED frame: " <> show controlFrame)
+        _                   -> hPutStrLn stderr ("UNHANDLED frame: " <> show controlFrame)
 
   where
     ignore :: String -> IO ()


### PR DESCRIPTION
DO NOT MERGE.

Whether or not to merge this function needs more reflection because of the possible race condition when receiving an early GOAWAY frame. #6 