### PR TITLE
Use withAsync to link all underlying asyncs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ GitHub: https://github.com/lucasdicioccio/http2-client/issues .
 
 ### Things that will likely change the API
 
-I think the fundamental are right but the following needs tweaking:
+I think the fundamentals are right but the following needs tweaking:
 
 - function to reset a stream will likely be blocking until a RST/EndStream is
   received so that all DATA frames are accounted for in the flow-control system
@@ -208,6 +208,3 @@ The current implementation follows the HTTP2 standard except for the following:
     CPU/latency-wise if the concurrency is high
 - consider most performant functions for HTTP2.HPACK encoding/decoding
   * currently using naive function 'Network.HPACK.encodeHeader'
-- consider using a typeclass or a way to change the frame client
-- we need a story for IO exceptions
-- we need a story for instrumentation

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -190,6 +190,7 @@ client QueryArgs{..} = do
                 runHttp2Client frameConn _encoderBufsize _decoderBufsize conf (throwTo parentThread) ignoreFallbackHandler
 
     withConn $ \conn -> do
+      linkAsyncs conn
       _addCredit (_incomingFlowControl conn) _initialWindowKick
       _ <- forkIO $ forever $ do
               updated <- _updateWindow $ _incomingFlowControl conn

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -184,9 +184,9 @@ client QueryArgs{..} = do
           }
     let withConn = case _verboseDebug of
             Verbose ->
-                runHttp2Client wrappedFrameConn _encoderBufsize _decoderBufsize conf
+                runHttp2Client wrappedFrameConn _encoderBufsize _decoderBufsize conf defaultGoAwayHandler
             NonVerbose ->
-                runHttp2Client frameConn _encoderBufsize _decoderBufsize conf
+                runHttp2Client frameConn _encoderBufsize _decoderBufsize conf defaultGoAwayHandler
 
     withConn $ \conn -> do
       _addCredit (_incomingFlowControl conn) _initialWindowKick

--- a/http2-client.cabal
+++ b/http2-client.cabal
@@ -1,5 +1,5 @@
 name:                http2-client
-version:             0.3.0.3
+version:             0.4.0.0
 synopsis:            A native HTTP2 client library.
 description:         Please read the README.md at the homepage.
 homepage:            https://github.com/lucasdicioccio/http2-client
@@ -33,7 +33,7 @@ library
 executable http2-client-exe
   hs-source-dirs:      app
   main-is:             Main.hs
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -O2
   build-depends:       base
                      , async
                      , bytestring

--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -550,7 +550,16 @@ ignoreFallbackHandler = const $ pure ()
 -- | A Handler for exceptional circumstances.
 type GoAwayHandler = RemoteSentGoAwayFrame -> IO ()
 
--- | Default GoAwayHandler throws a 'RemoteSentGoAwayFrame'.
+-- | Default GoAwayHandler throws a 'RemoteSentGoAwayFrame' in the current
+-- thread.
+--
+-- A probably sharper handler if you want to abruptly stop any operation is to
+-- get the 'ThreadId' of the main client thread and using
+-- 'Control.Exception.Base.throwTo'.
+--
+-- There's an inherent race condition when receiving a GoAway frame because the
+-- server will likely close the connection which will lead to TCP errors as
+-- well.
 defaultGoAwayHandler :: GoAwayHandler
 defaultGoAwayHandler = throwIO
 

--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -25,6 +25,7 @@ module Network.HTTP2.Client (
     , IncomingFlowControl(..)
     , OutgoingFlowControl(..)
     -- * Exceptions
+    , RemoteSentGoAwayFrame(..)
     -- * Misc.
     , FlagSetter
     , Http2ClientAsyncs(..)

--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -8,7 +8,7 @@
 -- For higher-level primitives, please refer to Network.HTTP2.Client.Helpers .
 module Network.HTTP2.Client (
     -- * Basics
-      newHttp2Client
+      runHttp2Client
     , withHttp2Stream
     , headers
     , sendData
@@ -25,11 +25,9 @@ module Network.HTTP2.Client (
     , IncomingFlowControl(..)
     , OutgoingFlowControl(..)
     -- * Exceptions
-    , linkHttp2Client
     -- * Misc.
     , FlagSetter
     , Http2ClientAsyncs(..)
-    , wrapFrameClient
     , _gtfo
     -- * Convenience re-exports
     , module Network.HTTP2.Client.FrameConnection
@@ -38,7 +36,7 @@ module Network.HTTP2.Client (
     ) where
 
 import           Control.Exception (bracket, throw)
-import           Control.Concurrent.Async (Async, async, race, link)
+import           Control.Concurrent.Async (Async, race, withAsync)
 import           Control.Concurrent.MVar (newMVar, takeMVar, putMVar)
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Chan (Chan, newChan, dupChan, readChan, writeChan)
@@ -176,8 +174,7 @@ data Http2Client = Http2Client {
 
 -- | Set of Async threads running an Http2Client.
 --
--- If you add other asyncs here, you should also modify
--- 'linkHttp2Client'.
+-- This asyncs are linked to the thread where the Http2Client is created.
 data Http2ClientAsyncs = Http2ClientAsyncs {
     _waitSettingsAsync   :: Async (FrameHeader, FramePayload)
   -- ^ Async waiting for the initial settings ACK.
@@ -195,19 +192,6 @@ data Http2ClientAsyncs = Http2ClientAsyncs {
   -- maximum-received streamID and starting the frame dispatch. See
   -- 'incomingFramesLoop'.
   }
-
--- | Links all asyncs threads of a client to the current thread.
---
--- See 'link'.
-linkHttp2Client :: Http2Client -> IO ()
-linkHttp2Client client = 
-    let Http2ClientAsyncs{..} = _asyncs client
-    in do
-        link _waitSettingsAsync
-        link _creditFlowsAsync
-        link _HPACKAsync
-        link _controlFramesAsync
-        link _incomingFramesAsync
 
 -- | Couples client and server settings together.
 data ConnectionSettings = ConnectionSettings {
@@ -277,25 +261,6 @@ data HpackEncoderContext = HpackEncoderContext {
   , _applySettings    :: Int -> IO ()
   }
 
--- | Starts a new Http2Client with a remote Host/Port. TLS ClientParams are
--- mandatory because we only support TLS-protected streams for now.
-newHttp2Client :: HostName
-               -- ^ Host to connect to.
-               -> PortNumber
-               -- ^ Port number to connect to (usually 443 on the web).
-               -> Int
-               -- ^ The buffersize for the Network.HPACK encoder.
-               -> Int
-               -- ^ The buffersize for the Network.HPACK decoder.
-               -> ClientParams
-               -- ^ The TLS client parameters (e.g., to allow some certificates).
-               -> SettingsList
-               -- ^ Initial SETTINGS that are sent as first frame.
-               -> IO Http2Client
-newHttp2Client host port encoderBufSize decoderBufSize tlsParams initSettings = do
-    conn <- newHttp2FrameConnection host port tlsParams
-    wrapFrameClient conn encoderBufSize decoderBufSize initSettings
-
 -- | Starts a new stream (i.e., one HTTP request + server-pushes).
 --
 -- You will typically call the returned 'StreamStarter' immediately to define
@@ -334,12 +299,12 @@ type FlagSetter = FrameFlags -> FrameFlags
 headers :: Http2Stream -> HeaderList -> FlagSetter -> IO StreamThread
 headers = _headers
 
--- | Prepares a client around a frame connection.
+-- | Starts a new Http2Client around a frame connection.
 --
 -- This is mostly useful if you want to muck around the Http2FrameConnection
 -- (e.g., for tracing frames) as well as for unit testing purposes. If you want
 -- to create a new connection you should likely use 'newHttp2Client' instead.
-wrapFrameClient
+runHttp2Client
   :: Http2FrameConnection
   -- ^ A frame connection.
   -> Int
@@ -348,8 +313,12 @@ wrapFrameClient
   -- ^ The buffersize for the Network.HPACK decoder.
   -> SettingsList
   -- ^ Initial SETTINGS that are sent as first frame.
-  -> IO Http2Client
-wrapFrameClient conn encoderBufSize decoderBufSize initSettings = do
+  -> (Http2Client -> IO a)
+  -- ^ Actions to run on the client.
+  -> IO a
+runHttp2Client conn encoderBufSize decoderBufSize initSettings mainHandler = do
+    let _close = closeConnection conn
+
     -- prepare hpack contexts
     hpackEncoder <- do
         let strategy = (HPACK.defaultEncodeStrategy { HPACK.useHuffman = True })
@@ -371,87 +340,82 @@ wrapFrameClient conn encoderBufSize decoderBufSize initSettings = do
     -- Initial thread receiving server frames.
     maxReceivedStreamId  <- newIORef 0
     serverFrames <- newChan
-    aIncoming <- async $ incomingFramesLoop conn serverFrames maxReceivedStreamId
+    let incomingLoop = incomingFramesLoop conn serverFrames maxReceivedStreamId
+    withAsync incomingLoop $ \aIncoming -> do
 
-    -- Thread handling control frames.
-    settings  <- newIORef defaultConnectionSettings
-    controlFrames <- dupChan serverFrames
-    aControl <- async $ incomingControlFramesLoop controlFrames settings hpackEncoder ackPing ackSettings
+      -- Thread handling control frames.
+      settings  <- newIORef defaultConnectionSettings
+      controlFrames <- dupChan serverFrames
+      let controlLoop = incomingControlFramesLoop controlFrames settings hpackEncoder ackPing ackSettings
+      withAsync controlLoop $ \aControl -> do
+        -- Thread handling push-promises and headers frames serializing the buffers.
+        serverStreamFrames <- dupChan serverFrames
+        serverHeaders <- newChan
+        hpackDecoder <- do
+            dt <- newDynamicTableForDecoding HPACK.defaultDynamicTableSize decoderBufSize
+            return dt
 
-    -- Thread handling push-promises and headers frames serializing the buffers.
-    serverStreamFrames <- dupChan serverFrames
-    serverHeaders <- newChan
-    hpackDecoder <- do
-        dt <- newDynamicTableForDecoding HPACK.defaultDynamicTableSize decoderBufSize
-        return dt
+        creditFrames <- dupChan serverFrames
 
-    creditFrames <- dupChan serverFrames
+        _outgoingFlowControl <- newOutgoingFlowControl settings 0 creditFrames
+        _incomingFlowControl <- newIncomingFlowControl settings controlStream
 
-    _outgoingFlowControl <- newOutgoingFlowControl settings 0 creditFrames
-    _incomingFlowControl <- newIncomingFlowControl settings controlStream
+        serverPushPromises <- newChan
 
-    serverPushPromises <- newChan
+        let hpackLoop = incomingHPACKFramesLoop serverStreamFrames serverHeaders serverPushPromises hpackDecoder
+        withAsync hpackLoop $ \aHPACK -> do
+          dataFrames <- dupChan serverFrames
+          let creditLoop = creditDataFramesLoop _incomingFlowControl dataFrames
+          withAsync creditLoop $ \aCredit -> do
+            conccurentStreams <- newIORef 0
+            let _startStream getWork = do
+                    maxConcurrency <- fromMaybe 100 . maxConcurrentStreams . _serverSettings
+                       <$> readIORef settings
+                    roomNeeded <- atomicModifyIORef' conccurentStreams
+                        (\n -> if n < maxConcurrency then (n + 1, 0) else (n, 1 + n - maxConcurrency))
+                    if roomNeeded > 0
+                    then
+                        return $ Left $ TooMuchConcurrency roomNeeded
+                    else do
+                        cont <- withClientStreamId $ \sid -> do
+                            initializeStream conn
+                                             settings
+                                             serverFrames
+                                             serverHeaders
+                                             serverPushPromises
+                                             hpackEncoder
+                                             sid
+                                             getWork
+                        v <- cont
+                        atomicModifyIORef' conccurentStreams (\n -> (n - 1, ()))
+                        return $ Right v
 
-    aHPACK <- async $ incomingHPACKFramesLoop serverStreamFrames
-                                              serverHeaders
-                                              serverPushPromises
-                                              hpackDecoder
+            let _ping dat = do
+                    -- Need to dupChan before sending the query to avoid missing a fast
+                    -- answer if the network is fast.
+                    pingFrames <- dupChan serverFrames
+                    sendPingFrame controlStream id dat
+                    return $ waitFrame (isPingReply dat) pingFrames
+            let _settings settslist = do
+                    -- Much like _ping, we need to dupChan before sending the query.
+                    pingFrames <- dupChan serverFrames
+                    sendSettingsFrame controlStream id settslist
+                    return $ do
+                        ret <- waitFrame isSettingsReply pingFrames
+                        atomicModifyIORef' settings
+                            (\(ConnectionSettings cli srv) ->
+                                (ConnectionSettings (HTTP2.updateSettings cli settslist) srv, ()))
+                        return ret
+            let _goaway err errStr = do
+                    sId <- readIORef maxReceivedStreamId
+                    sendGTFOFrame controlStream sId err errStr
 
-    dataFrames <- dupChan serverFrames
-    aCredit <- async $ creditDataFramesLoop _incomingFlowControl dataFrames
+            let _paylodSplitter = settingsPayloadSplitter <$> readIORef settings
 
-    conccurentStreams <- newIORef 0
-    let _startStream getWork = do
-            maxConcurrency <- fromMaybe 100 . maxConcurrentStreams . _serverSettings
-               <$> readIORef settings
-            roomNeeded <- atomicModifyIORef' conccurentStreams
-                (\n -> if n < maxConcurrency then (n + 1, 0) else (n, 1 + n - maxConcurrency))
-            if roomNeeded > 0
-            then
-                return $ Left $ TooMuchConcurrency roomNeeded
-            else do
-                cont <- withClientStreamId $ \sid -> do
-                    initializeStream conn
-                                     settings
-                                     serverFrames
-                                     serverHeaders
-                                     serverPushPromises
-                                     hpackEncoder
-                                     sid
-                                     getWork
-                v <- cont
-                atomicModifyIORef' conccurentStreams (\n -> (n - 1, ()))
-                return $ Right v
-
-    let _ping dat = do
-            -- Need to dupChan before sending the query to avoid missing a fast
-            -- answer if the network is fast.
-            pingFrames <- dupChan serverFrames
-            sendPingFrame controlStream id dat
-            return $ waitFrame (isPingReply dat) pingFrames
-    let _settings settslist = do
-            -- Much like _ping, we need to dupChan before sending the query.
-            pingFrames <- dupChan serverFrames
-            sendSettingsFrame controlStream id settslist
-            return $ do
-                ret <- waitFrame isSettingsReply pingFrames
-                atomicModifyIORef' settings
-                    (\(ConnectionSettings cli srv) ->
-                        (ConnectionSettings (HTTP2.updateSettings cli settslist) srv, ()))
-                return ret
-    let _goaway err errStr = do
-            sId <- readIORef maxReceivedStreamId
-            sendGTFOFrame controlStream sId err errStr
-
-    let _paylodSplitter = settingsPayloadSplitter <$> readIORef settings
-
-    aSettings <- async =<< _settings initSettings
-
-    let _asyncs = Http2ClientAsyncs aSettings aCredit aHPACK aControl aIncoming
-
-    let _close = closeConnection conn
-
-    return $ Http2Client{..}
+            settsIO <- _settings initSettings
+            withAsync settsIO $ \aSettings -> do
+                let _asyncs = Http2ClientAsyncs aSettings aCredit aHPACK aControl aIncoming
+                mainHandler $ Http2Client{..}
 
 initializeStream
   :: Exception e

--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -51,6 +51,7 @@ import           Network.HPACK as HPACK
 import           Network.HTTP2 as HTTP2
 import           Network.Socket (HostName, PortNumber)
 import           Network.TLS (ClientParams)
+import           System.IO (hPutStrLn, stderr)
 
 import           Network.HTTP2.Client.FrameConnection
 
@@ -523,7 +524,7 @@ incomingControlFramesLoop frames settings hpackEncoder ackPing ackSettings = for
         (GoAwayFrame lastSid errCode reason)  ->
              throwIO $ RemoteSentGoAwayFrame lastSid errCode reason
 
-        _                   -> putStrLn ("UNHANDLED frame: " <> show controlFrame)
+        _                   -> hPutStrLn stderr ("UNHANDLED frame: " <> show controlFrame)
 
   where
     ignore :: String -> IO ()

--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -35,7 +35,7 @@ module Network.HTTP2.Client (
     , module Network.TLS
     ) where
 
-import           Control.Exception (bracket, throw)
+import           Control.Exception (bracket, throwIO)
 import           Control.Concurrent.Async (Async, race, withAsync)
 import           Control.Concurrent.MVar (newMVar, takeMVar, putMVar)
 import           Control.Concurrent (threadDelay)
@@ -520,11 +520,19 @@ incomingControlFramesLoop frames settings hpackEncoder ackPing ackSettings = for
                 ignore "PingFrame replies waited for in the requestor thread"
         (WindowUpdateFrame _ )  ->
                 ignore "connection-wide WindowUpdateFrame waited for in OutgoingFlowControl threads"
+        (GoAwayFrame lastSid errCode reason)  ->
+             throwIO $ RemoteSentGoAwayFrame lastSid errCode reason
+
         _                   -> putStrLn ("UNHANDLED frame: " <> show controlFrame)
 
   where
     ignore :: String -> IO ()
     ignore _ = return ()
+
+-- | An exception thrown when the server sends a GoAwayFrame.
+data RemoteSentGoAwayFrame = RemoteSentGoAwayFrame !StreamId !ErrorCodeId !ByteString
+  deriving Show
+instance Exception RemoteSentGoAwayFrame
 
 -- | We currently need a specific loop for crediting streams because a client
 -- user may programmatically reset and stop listening for a stream and stop
@@ -838,7 +846,7 @@ waitFrame test chan =
   where
     loop = do
         (fHead, fPayload) <- readChan chan
-        let dat = either throw id fPayload
+        dat <- either throwIO pure fPayload
         if test fHead dat
         then return (fHead, dat)
         else loop


### PR DESCRIPTION
This API breaking change provides the cleanest way to avoid leaking
threads at the expense of delimiting the Http2Client lifetime within a
callback block.

This design addresses #6 by making sure all threads at least have a shared fate when an exception occurs.