### PR TITLE
Refactor dispatching logic.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -273,22 +273,28 @@ client QueryArgs{..} = do
 data DumpType = MainFile | PushPromiseFile
 
 dump :: DumpType -> Path -> Int -> Int -> FilePath -> StreamResponse -> IO ()
-dump MainFile _ _ _ ":none" (hdrs, _) = do
+dump MainFile _ _ _ ":none" (hdrs, _, trls) = do
     timePrint hdrs
-dump MainFile _ _ _ ":stdout" (hdrs, body) = do
-    timePrint hdrs
-    ByteString.putStrLn body
-dump PushPromiseFile _ _ _ ":stdout" (hdrs, _) = do
-    timePrint hdrs
-dump MainFile _ _ _ ":stdout-pp" (hdrs, body) = do
+    timePrint trls
+dump MainFile _ _ _ ":stdout" (hdrs, body, trls) = do
     timePrint hdrs
     ByteString.putStrLn body
-dump PushPromiseFile _ _ _ ":stdout-pp" (hdrs, body) = do
+    timePrint trls
+dump PushPromiseFile _ _ _ ":stdout" (hdrs, _, trls) = do
+    timePrint hdrs
+    timePrint trls
+dump MainFile _ _ _ ":stdout-pp" (hdrs, body, trls) = do
     timePrint hdrs
     ByteString.putStrLn body
-dump _ querystring nquery nthread prefix (hdrs, body) = do
+    timePrint trls
+dump PushPromiseFile _ _ _ ":stdout-pp" (hdrs, body, trls) = do
+    timePrint hdrs
+    ByteString.putStrLn body
+    timePrint trls
+dump _ querystring nquery nthread prefix (hdrs, body, trls) = do
     timePrint hdrs
     ByteString.writeFile filepath body
+    timePrint trls
   where
     filepath = mconcat [ prefix
                        , "/" 

--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -12,6 +12,7 @@ module Network.HTTP2.Client (
     , newHttp2Client
     , withHttp2Stream
     , headers
+    , trailers
     , sendData
     -- * Starting clients
     , Http2Client(..)
@@ -46,7 +47,7 @@ import           Control.Concurrent.Async (Async, async, race, withAsync, link)
 import           Control.Exception (bracket, throwIO, SomeException, catch)
 import           Control.Concurrent.MVar (newMVar, takeMVar, putMVar)
 import           Control.Concurrent (threadDelay)
-import           Control.Monad (forever, join, when, forM_)
+import           Control.Monad (forever, join, void, when, forM_)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import           Data.IORef (newIORef, atomicModifyIORef', readIORef)
@@ -250,6 +251,12 @@ data Http2Stream = Http2Stream {
   -- can be useful if you intend to handle the framing yourself.
   , _waitPushPromise :: Maybe (PushPromiseHandler -> IO ())
   }
+
+-- | Sends HTTP trailers.
+--
+-- Trailers should be the last thing sent over a stream.
+trailers :: Http2Stream -> HPACK.HeaderList -> (FrameFlags -> FrameFlags) -> IO ()
+trailers stream hdrs mod = void $ _headers stream hdrs mod
 
 -- | Handler upon receiving a PUSH_PROMISE from the server.
 --

--- a/src/Network/HTTP2/Client/Dispatch.hs
+++ b/src/Network/HTTP2/Client/Dispatch.hs
@@ -53,14 +53,13 @@ data StreamFSMState =
 data StreamEvent =
     StreamHeadersEvent !FrameHeader !HeaderList
   | StreamPushPromiseEvent !FrameHeader !StreamId !HeaderList
-  | StreamData !FrameHeader ByteString
+  | StreamDataEvent !FrameHeader ByteString
   | StreamErrorEvent !FrameHeader ErrorCode
   deriving Show
 
 data StreamState = StreamState {
     _streamStateWindowUpdatesChan :: !(Chan (FrameHeader, FramePayload))
   , _streamStateEvents            :: !(Chan StreamEvent)
-  , _streamStateStreamFramesChan  :: !DispatchChan
   , _streamStateFSMState          :: !StreamFSMState
   }
 
@@ -233,13 +232,11 @@ newDispatchHPACKIO decoderBufSize =
         decoderBufSize
 
 data DispatchStream = DispatchStream {
-    _dispatchStreamId               :: !StreamId
-  , _dispatchStreamReadEvents       :: !(Chan StreamEvent)
-  , _dispatchStreamReadStreamFrames :: !DispatchChan
+    _dispatchStreamId         :: !StreamId
+  , _dispatchStreamReadEvents :: !(Chan StreamEvent)
   }
 
 newDispatchStreamIO :: StreamId -> IO DispatchStream
 newDispatchStreamIO sid =
     DispatchStream <$> pure sid
-                   <*> newChan
                    <*> newChan

--- a/src/Network/HTTP2/Client/Helpers.hs
+++ b/src/Network/HTTP2/Client/Helpers.hs
@@ -27,7 +27,6 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async (race)
-import           Control.Monad (forever)
 
 import Network.HTTP2.Client
 


### PR DESCRIPTION
This significantly changes refactors the per-stream event dispatching logic so that all events for a same stream are serialized.

This serialization allows to safely read data and then read trailers. However, callers now cannot expect to have only DATA or HEADERS frames on a same channel. Hence, _waitHeaders and _waitData are decommissioned. Similarly, serialized PUSH_PROMISES mean that it is no longer possible to wait for push-promise on a separate channel.

A modification of the waitStream helper takes the push-promise handler as extra parameter and returns the potential trailers.

Closes #41 .