### PR TITLE
Socket-based networking.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -262,7 +262,7 @@ client QueryArgs{..} = do
     tlsParams = TLS.ClientParams {
           TLS.clientWantSessionResume    = Nothing
         , TLS.clientUseMaxFragmentLength = Nothing
-        , TLS.clientServerIdentification = ("127.0.0.1", "")
+        , TLS.clientServerIdentification = (_host, ByteString.pack $ show _port)
         , TLS.clientUseServerNameIndication = True
         , TLS.clientShared               = def
         , TLS.clientHooks                = def { TLS.onServerCertificate = \_ _ _ _ -> return []

--- a/http2-client.cabal
+++ b/http2-client.cabal
@@ -24,7 +24,6 @@ library
   build-depends:       base >= 4.7 && < 5
                      , async >= 2.1 && < 3
                      , bytestring >= 0.10 && < 1
-                     , connection >= 0.2 && < 1
                      , containers >= 0.5 && < 1
                      , http2 >= 1.6 && < 2
                      , network >= 2.6 && < 3

--- a/src/Network/HTTP2/Client/FrameConnection.hs
+++ b/src/Network/HTTP2/Client/FrameConnection.hs
@@ -87,13 +87,12 @@ newHttp2FrameConnection host port params = do
 
     -- Define handlers.
     let makeClientStream streamID = 
-            let putFrame modifyFF frame = do
+            let putFrame modifyFF frame =
                     let info = encodeInfo modifyFF streamID
-                    _sendRaw http2conn $
-                        HTTP2.encodeFrame info frame
+                    in HTTP2.encodeFrame info frame
                 putFrames f = writeProtect . void $ do
                     xs <- f
-                    traverse (uncurry putFrame) xs
+                    _sendRaw http2conn $ fmap (uncurry putFrame) xs
              in Http2FrameClientStream putFrames streamID
 
         nextServerFrameChunk = Http2ServerStream $ do

--- a/src/Network/HTTP2/Client/RawConnection.hs
+++ b/src/Network/HTTP2/Client/RawConnection.hs
@@ -7,16 +7,19 @@ module Network.HTTP2.Client.RawConnection (
     , newRawHttp2Connection
     ) where
 
+import           Data.IORef (newIORef, readIORef, writeIORef)
 import           Data.ByteString (ByteString)
-import           Network.Connection (connectTo, initConnectionContext, ConnectionParams(..), TLSSettings(..), connectionPut, connectionGetExact, connectionClose)
+import qualified Data.ByteString as ByteString
+import           Data.ByteString.Lazy (fromChunks)
+import           Data.Monoid ((<>))
 import qualified Network.HTTP2 as HTTP2
-import           Network.Socket (HostName, PortNumber)
+import           Network.Socket hiding (recv)
+import           Network.Socket.ByteString
 import qualified Network.TLS as TLS
-
 
 -- TODO: catch connection errrors
 data RawHttp2Connection = RawHttp2Connection {
-    _sendRaw :: ByteString -> IO ()
+    _sendRaw :: [ByteString] -> IO ()
   -- ^ Function to send raw data to the server.
   , _nextRaw :: Int -> IO ByteString
   -- ^ Function to block reading a datachunk of a given size from the server.
@@ -35,22 +38,65 @@ newRawHttp2Connection :: HostName
                       -- overwritten to always return ["h2", "h2-17"].
                       -> IO RawHttp2Connection
 newRawHttp2Connection host port mparams = do
-    -- Connects to SSL.
-    ctx <- initConnectionContext
-    conn <- connectTo ctx connParams
+    -- Connects to TCP.
+    let hints = defaultHints { addrFlags = [AI_NUMERICSERV], addrSocketType = Stream }
+    addr:_ <- getAddrInfo (Just hints) (Just host) (Just $ show port)
+    skt <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+    connect skt (addrAddress addr)
 
-    -- Define raw byte-stream handlers.
-    let putRaw dat    = connectionPut conn dat
-    let getRaw amount = connectionGetExact conn amount
-    let doClose       = connectionClose conn
+    -- Prepare structure with abstract API.
+    conn <- maybe (plainTextRaw skt) (tlsRaw skt) mparams
 
     -- Initializes the HTTP2 stream.
-    putRaw HTTP2.connectionPreface
+    _sendRaw conn [HTTP2.connectionPreface]
+
+    return conn
+
+
+plainTextRaw :: Socket -> IO RawHttp2Connection
+plainTextRaw skt = do
+    let putRaw = sendMany skt
+    remainder <- newIORef ""
+    let getRaw amount = do
+            -- TODO: improve re-writing of remainders by storing chunks instead of concatening chunks
+            buf <- readIORef remainder
+            if amount > ByteString.length buf
+            then do
+               dat <- recv skt 4096
+               writeIORef remainder $ buf <> dat
+               getRaw amount
+            else do
+               writeIORef remainder $ ByteString.drop amount buf
+               return $ ByteString.take amount buf
+    let doClose = close skt
+    return $ RawHttp2Connection putRaw getRaw doClose
+
+tlsRaw :: Socket -> TLS.ClientParams -> IO RawHttp2Connection
+tlsRaw skt params = do
+    -- Connects to SSL
+    tlsContext <- TLS.contextNew skt (modifyParams params)
+    TLS.handshake tlsContext
+
+    -- Define raw byte-stream handlers.
+    let putRaw        = TLS.sendData tlsContext . fromChunks
+    remainder <- newIORef ""
+    let getRaw amount = do
+            -- TODO: improve re-writing of remainders by storing chunks instead of concatening chunks
+            buf <- readIORef remainder
+            if amount > ByteString.length buf
+            then do
+               dat <- TLS.recvData tlsContext
+               writeIORef remainder $ buf <> dat
+               getRaw amount
+            else do
+               writeIORef remainder $ ByteString.drop amount buf
+               return $ ByteString.take amount buf
+    let doClose       = TLS.bye tlsContext >> TLS.contextClose tlsContext
 
     return $ RawHttp2Connection putRaw getRaw doClose
   where
-    overwriteALPNHook params = (TLS.clientHooks params) {
-        TLS.onSuggestALPN = return $ Just [ "h2", "h2-17" ]
+    modifyParams prms = prms {
+        TLS.clientHooks = (TLS.clientHooks prms) {
+            TLS.onSuggestALPN = return $ Just [ "h2", "h2-17" ]
+          }
       }
-    modifyParams params = params { TLS.clientHooks = overwriteALPNHook params }
-    connParams = ConnectionParams host port (TLSSettings . modifyParams <$> mparams) Nothing


### PR DESCRIPTION
Sidesteps the 'connection' package to be able to modify the socket-writing backend.
Forces TLS.ClientParams to be filled with the proper SNI information.