### PR TITLE
Close the connection at the end of 'runHttp2Client'.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -256,7 +256,6 @@ client QueryArgs{..} = do
 
 
       _gtfo conn HTTP2.NoError _finalMessage
-      _close conn
   where
     tlsParams = TLS.ClientParams {
           TLS.clientWantSessionResume    = Nothing

--- a/http2-client.cabal
+++ b/http2-client.cabal
@@ -1,5 +1,5 @@
 name:                http2-client
-version:             0.7.0.1
+version:             0.8.0.0
 synopsis:            A native HTTP2 client library.
 description:         Please read the README.md at the homepage.
 homepage:            https://github.com/lucasdicioccio/http2-client


### PR DESCRIPTION
Breaking-change: code compiling with `0.7.x.y` will still compile but
will, in all likelihood, raise IOExceptions at the end of the processing
instead of terminating cleanly. Conversely, code that was leaking
connections will now properly close them.