### PR TITLE
Fix observing base window size in initHttp2Client

### DIFF
--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -419,10 +419,11 @@ initHttp2Client conn encoderBufSize decoderBufSize goAwayHandler fallbackHandler
                                             goAwayHandler
                                             fallbackHandler
 
-    let baseWindowSize = return HTTP2.defaultInitialWindowSize
-    _initIncomingFlowControl <- lift $ newIncomingFlowControl dispatchControl baseWindowSize (sendWindowUpdateFrame controlStream)
+    let baseIncomingWindowSize = initialWindowSize . _clientSettings <$> readSettings dispatchControl
+        baseOutgoingWindowSize = initialWindowSize . _serverSettings <$> readSettings dispatchControl
+    _initIncomingFlowControl <- lift $ newIncomingFlowControl dispatchControl baseIncomingWindowSize (sendWindowUpdateFrame controlStream)
     windowUpdatesChan <- newChan
-    _initOutgoingFlowControl <- lift $ newOutgoingFlowControl dispatchControl windowUpdatesChan baseWindowSize
+    _initOutgoingFlowControl <- lift $ newOutgoingFlowControl dispatchControl windowUpdatesChan baseOutgoingWindowSize
 
     dispatchHPACK <- newDispatchHPACKIO decoderBufSize
     (incomingLoop,endIncomingLoop) <- dispatchLoop conn dispatch dispatchControl windowUpdatesChan _initIncomingFlowControl dispatchHPACK


### PR DESCRIPTION
This fixes a bug which could cause `_withdrawCredit` from a connection's `OutgoingFlowControl` to spin forever. Without this patch, `getBase` in `newOutgoingFlowControl` would always return the default initial window size, even if we had received an updated window size from the server. If the server sets an initial window size not equal to the default, `waitSettingsChange` would almost always win the race against `waitSomeCredit`, causing `withdraw` to spin forever.

The current definition of `withdraw` is still problematic, consider this ordering:
- `waitSomeCredit` finishes its call to `readChan frames`.
- `waitSettingsChange` returns, winning the `race`.
- `withdraw` calls `receive 0` and recurses.
- The credit obtained in `waitSomeCredit` is lost.

With this patch this bad ordering should be exceedingly rare; without this patch, it happens almost every time we run out of outgoing credit!