### PR TITLE
change cabal file to make dependency requirements PVP compliant

### DIFF
--- a/http2-client.cabal
+++ b/http2-client.cabal
@@ -22,19 +22,19 @@ library
                      , Network.HTTP2.Client.RawConnection
   other-modules:       Network.HTTP2.Client.Channels
                      , Network.HTTP2.Client.Dispatch
-  build-depends:       base >= 4.7 && < 5
-                     , async >= 2.1 && < 3
-                     , bytestring >= 0.10 && < 1
-                     , containers >= 0.5 && < 1
-                     , deepseq >= 1.4 && < 2
+  build-depends:       base >= 4.7 && < 4.15
+                     , async >= 2.1 && < 2.3
+                     , bytestring >= 0.10 && < 0.11
+                     , containers >= 0.5 && < 0.7
+                     , deepseq >= 1.4 && < 1.5
                      , http2 >= 1.6 && < 2.1
                      , lifted-async >= 0.10 && < 0.11
                      , lifted-base >= 0.2 && < 0.3
-                     , mtl >= 2.2 && < 3
-                     , network >= 2.6 && < 4
-                     , stm >= 2.4 && < 3
-                     , time >= 1.8 && < 2
-                     , tls >= 1.4 && < 2
+                     , mtl >= 2.2 && < 2.3
+                     , network >= 2.6 && < 3.2
+                     , stm >= 2.4 && < 2.6
+                     , time >= 1.8 && < 1.10
+                     , tls >= 1.4 && < 1.6
                      , transformers-base >= 0.4 && < 0.5
   default-language:    Haskell2010
 


### PR DESCRIPTION
Version numbers are taken from the latest stackage resolver (18.3) and bumped up to one higher major version pair.