### PR TITLE
Fix build for 9.x

### DIFF
--- a/http2-client.cabal
+++ b/http2-client.cabal
@@ -22,7 +22,7 @@ library
                      , Network.HTTP2.Client.RawConnection
   other-modules:       Network.HTTP2.Client.Channels
                      , Network.HTTP2.Client.Dispatch
-  build-depends:       base >= 4.7 && < 4.15
+  build-depends:       base >= 4.7 && < 4.16
                      , async >= 2.1 && < 2.3
                      , bytestring >= 0.10 && < 0.11
                      , containers >= 0.5 && < 0.7

--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -283,7 +283,7 @@ type PushPromiseHandler =
 --
 -- Please refer to 'StreamStarter' and 'StreamDefinition' for more.
 withHttp2Stream :: Http2Client -> StreamStarter a
-withHttp2Stream = _startStream
+withHttp2Stream client = _startStream client
 
 -- | Type synonym for functions that modify flags.
 --

--- a/stack-lts-18.21.yaml
+++ b/stack-lts-18.21.yaml
@@ -1,0 +1,7 @@
+resolver: lts-18.21
+packages:
+  - "."
+extra-deps:
+  - http2-2.0.6
+flags: {}
+extra-package-dbs: []

--- a/stack-nightly-2022-01-10.yaml
+++ b/stack-nightly-2022-01-10.yaml
@@ -1,0 +1,7 @@
+resolver: nightly-2022-01-10
+packages:
+  - "."
+extra-deps:
+  - http2-2.0.6
+flags: {}
+extra-package-dbs: []


### PR DESCRIPTION
This is a less invasive version of #83 which does the minimal changes to make it work with GHC 9.x, but doesn't attempt to work with `http2` version 3 (the one with the `Client` module.) The expansion of `withHttp2Stream` is required because of the changes to `ImpredicativeTypes`, but I've checked that this is a backwards compatible change by building with the other `stack.yaml` files.

By the way, we need this change to support [`mu-haskell`](https://github.com/higherkindness/mu-haskell) in GHC 9.x.