### PR TITLE
Relax lower bounds on `tls`

### DIFF
--- a/http2-client.cabal
+++ b/http2-client.cabal
@@ -34,7 +34,7 @@ library
                      , network >= 2.6 && < 3.2
                      , stm >= 2.4 && < 2.8
                      , time >= 1.8 && < 1.15
-                     , tls >= 2 && < 2.0.3
+                     , tls >= 1.8.0 && < 2.0.3
                      , transformers-base >= 0.4 && < 0.5
   default-language:    Haskell2010
 

--- a/stack-nightly-2023-08-29.yaml
+++ b/stack-nightly-2023-08-29.yaml
@@ -1,7 +1,6 @@
 resolver: nightly-2023-08-29
 packages:
   - "."
-extra-deps:
-  - http2-2.0.6
+extra-deps: []
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
As described in #90, the lower bounds on `tls` in the latest version on Hackage is incompatible with the upper bounds on `tls` in `http2-client-grpc`. My minimal testing (`stack build` and `stack test`) suggests that this package is compatible with at least `tls-1.8.0`.

If possible, please publish a meta-revision with this update.

Thanks so much for all your hard work!