### PR TITLE
Fix build with http2 >= 5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 stack*.lock
+dist-newstyle

--- a/http2-client.cabal
+++ b/http2-client.cabal
@@ -25,9 +25,10 @@ library
   build-depends:       base >= 4.7 && < 4.20
                      , async >= 2.1 && < 2.3
                      , bytestring >= 0.11 && < 0.13
+                     , case-insensitive >= 1.2 && < 1.3
                      , containers >= 0.5 && < 0.8
                      , deepseq >= 1.4 && < 1.6
-                     , http2 >= 4.1 && < 6
+                     , http2 >= 4.1 && < 5.3
                      , lifted-async >= 0.10 && < 0.11
                      , lifted-base >= 0.2 && < 0.3
                      , mtl >= 2.2 && < 2.4

--- a/src/Network/HTTP2/Client/Dispatch.hs
+++ b/src/Network/HTTP2/Client/Dispatch.hs
@@ -9,6 +9,7 @@ import Control.Exception (throwIO)
 import Control.Monad.Base (MonadBase, liftBase)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Internal as ByteString
+import qualified Data.CaseInsensitive as CI
 import Data.IORef.Lifted (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
@@ -17,13 +18,15 @@ import Foreign.Marshal.Alloc (finalizerFree, mallocBytes)
 import GHC.Exception (Exception)
 import Network.HPACK as HPACK
 import qualified Network.HPACK.Token as HPACK
+import Network.HTTP2.Client.Channels
+import Network.HTTP2.Client.Exceptions
 import Network.HTTP2.Frame as HTTP2
 #if MIN_VERSION_http2(5,0,0)
 import "http2" Network.HTTP2.Client (Settings, defaultSettings)
+#if MIN_VERSION_http2(5,2,0)
+type HeaderList = [(ByteString, ByteString)]
 #endif
-
-import Network.HTTP2.Client.Channels
-import Network.HTTP2.Client.Exceptions
+#endif
 
 type DispatchChan = FramesChan FrameDecodeError
 

--- a/src/Network/HTTP2/Client/Helpers.hs
+++ b/src/Network/HTTP2/Client/Helpers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | A toolbox with high-level functions to interact with an established HTTP2
@@ -11,7 +12,7 @@ module Network.HTTP2.Client.Helpers (
   -- * Sending and receiving HTTP body
     upload
   , waitStream
-  , fromStreamResult 
+  , fromStreamResult
   , StreamResult
   , StreamResponse
   -- * Diagnostics
@@ -23,12 +24,16 @@ module Network.HTTP2.Client.Helpers (
 import           Data.Time.Clock (UTCTime, getCurrentTime)
 import qualified Network.HTTP2.Frame as HTTP2
 import qualified Network.HPACK as HPACK
+#if !MIN_VERSION_http2(5,2,0)
+import           Network.HPACK as HPACK (HeaderList)
+#endif
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import           Control.Concurrent.Lifted (threadDelay)
 import           Control.Concurrent.Async.Lifted (race)
 
 import Network.HTTP2.Client
+import Network.HTTP2.Client.Dispatch
 import Network.HTTP2.Client.Exceptions
 
 -- | Opaque type to express an action which timed out.
@@ -57,10 +62,10 @@ ping conn timeout msg = do
 -- | Result containing the unpacked headers and all frames received in on a
 -- stream. See 'StreamResponse' and 'fromStreamResult' to get a higher-level
 -- utility.
-type StreamResult = (Either HTTP2.ErrorCode HPACK.HeaderList, [Either HTTP2.ErrorCode ByteString], Maybe HPACK.HeaderList)
+type StreamResult = (Either HTTP2.ErrorCode HeaderList, [Either HTTP2.ErrorCode ByteString], Maybe HeaderList)
 
 -- | An HTTP2 response, once fully received, is made of headers and a payload.
-type StreamResponse = (HPACK.HeaderList, ByteString, Maybe HPACK.HeaderList)
+type StreamResponse = (HeaderList, ByteString, Maybe HeaderList)
 
 -- | Uploads a whole HTTP body at a time.
 --


### PR DESCRIPTION
@lucasdicioccio 
The build fails when http2 5.2 is available, as the build plan won't pick an older version.

In http 5.2 `SettingsHeaderTableSize` was [renamed](https://github.com/kazu-yamamoto/http2/pull/114/files#diff-4c760e8aac520b52cf5b5bebe4c2ce5ad0a6386eb5a2d4f3be6c826d170c6b84L76) while `HeaderList` was [removed](https://github.com/kazu-yamamoto/http2/pull/114/files#diff-b5b46dcb7b0065b1194f4b7b046621432c7380aa81679ef2c69ea1fd191c5b58L37-L53), and its old `HeaderName = ByteString` is now the case-insensitive one from [http-types](https://hackage.haskell.org/package/http-types-0.12.4/docs/Network-HTTP-Types.html#g:8)

AFAICT this maintains the old behavior in that we keep case-sensitivity, so as to only fix the build.
Probably best to re-evaluate whether the new behavior should be adopted somewhere