### PR TITLE
Update for http2 >=5.2

### DIFF
--- a/http2-client.cabal
+++ b/http2-client.cabal
@@ -35,7 +35,7 @@ library
                      , network >= 2.6 && < 3.2
                      , stm >= 2.4 && < 2.8
                      , time >= 1.8 && < 1.15
-                     , tls >= 1.8.0 && < 2.0.3
+                     , tls >= 1.8 && < 2.2
                      , transformers-base >= 0.4 && < 0.5
   default-language:    Haskell2010
 

--- a/http2-client.cabal
+++ b/http2-client.cabal
@@ -22,9 +22,10 @@ library
                      , Network.HTTP2.Client.RawConnection
   other-modules:       Network.HTTP2.Client.Channels
                      , Network.HTTP2.Client.Dispatch
-  build-depends:       base >= 4.7 && < 4.20
+  build-depends:       base >= 4.7 && < 4.21
                      , async >= 2.1 && < 2.3
                      , bytestring >= 0.11 && < 0.13
+                     , case-insensitive >= 1.2 && < 1.3
                      , containers >= 0.5 && < 0.8
                      , deepseq >= 1.4 && < 1.6
                      , http2 >= 4.1 && < 6

--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -260,7 +260,7 @@ data StreamThread = CST
 -- | Record holding functions one can call while in an HTTP2 client stream.
 data Http2Stream = Http2Stream
     { _headers ::
-        HPACK.HeaderList ->
+        [Header] ->
         (FrameFlags -> FrameFlags) ->
         ClientIO StreamThread
     -- ^ Starts the stream with HTTP headers. Flags modifier can use
@@ -278,14 +278,14 @@ data Http2Stream = Http2Stream
     -- and hence does not respect the RFC if sending large blocks. Use 'sendData'
     -- to chunk and send naively according to server\'s preferences. This function
     -- can be useful if you intend to handle the framing yourself.
-    , _handlePushPromise :: StreamId -> HeaderList -> PushPromiseHandler -> ClientIO ()
+    , _handlePushPromise :: StreamId -> [Header] -> PushPromiseHandler -> ClientIO ()
     }
 
 {- | Sends HTTP trailers.
 
 Trailers should be the last thing sent over a stream.
 -}
-trailers :: Http2Stream -> HPACK.HeaderList -> (FrameFlags -> FrameFlags) -> ClientIO ()
+trailers :: Http2Stream -> [Header] -> (FrameFlags -> FrameFlags) -> ClientIO ()
 trailers stream hdrs flagmod = void $ _headers stream hdrs flagmod
 
 {- | Handler upon receiving a PUSH_PROMISE from the server.
@@ -299,7 +299,7 @@ client-initiated stream. Longer term we may move passing this handler to the
 '_startStream' instead of 'newHttp2Client' (as it is for now).
 -}
 type PushPromiseHandler =
-    StreamId -> Http2Stream -> HeaderList -> IncomingFlowControl -> OutgoingFlowControl -> ClientIO ()
+    StreamId -> Http2Stream -> [Header] -> IncomingFlowControl -> OutgoingFlowControl -> ClientIO ()
 
 {- | Starts a new stream (i.e., one HTTP request + server-pushes).
 
@@ -339,7 +339,7 @@ Note that we currently enforce the 'HTTP2.setEndHeader' but this design
 choice may change in the future. Hence, we recommend you use
 'HTTP2.setEndHeader' as well.
 -}
-headers :: Http2Stream -> HeaderList -> FlagSetter -> ClientIO StreamThread
+headers :: Http2Stream -> [Header] -> FlagSetter -> ClientIO StreamThread
 headers = _headers
 
 {- | Starts a new Http2Client around a frame connection.
@@ -687,7 +687,11 @@ dispatchControlFramesStep windowUpdatesChan controlFrame@(fh, payload) control@(
                     maybe
                         (return ())
                         (_applySettings _dispatchControlHpackEncoder)
+#if MIN_VERSION_http2(5,2,0)
+                        (lookup SettingsTokenHeaderTableSize settsList)
+#else
                         (lookup SettingsHeaderTableSize settsList)
+#endif
                 _dispatchControlAckSettings
             | otherwise -> do
                 handler <- lookupAndReleaseSetSettingsHandler control
@@ -748,8 +752,8 @@ data HPACKLoopDecision
 data HPACKStepResult
     = WaitContinuation !((FrameHeader, Either FrameDecodeError FramePayload) -> ClientIO HPACKStepResult)
     | FailedHeaders !FrameHeader !StreamId ErrorCode
-    | FinishedWithHeaders !FrameHeader !StreamId (IO HeaderList)
-    | FinishedWithPushPromise !FrameHeader !StreamId !StreamId (IO HeaderList)
+    | FinishedWithHeaders !FrameHeader !StreamId (IO [Header])
+    | FinishedWithPushPromise !FrameHeader !StreamId !StreamId (IO [Header])
 
 dispatchHPACKFramesStep ::
     (FrameHeader, FramePayload) ->
@@ -881,7 +885,7 @@ newOutgoingFlowControl control frames getBase = do
 sendHeaders ::
     Http2FrameClientStream ->
     HpackEncoderContext ->
-    HeaderList ->
+    [Header] ->
     PayloadSplitter ->
     (FrameFlags -> FrameFlags) ->
     ClientIO StreamThread
@@ -1032,7 +1036,11 @@ compat_updateSettings :: Settings -> SettingsList -> Settings
 #if MIN_VERSION_http2(5,0,0)
 compat_updateSettings settings kvs = foldl' update settings kvs
   where
+#if MIN_VERSION_http2(5,2,0)
+    update def (SettingsTokenHeaderTableSize,x)      = def { headerTableSize = x }
+#else
     update def (SettingsHeaderTableSize,x)      = def { headerTableSize = x }
+#endif
     -- fixme: x should be 0 or 1
     update def (SettingsEnablePush,x)           = def { enablePush = x > 0 }
     update def (SettingsMaxConcurrentStreams,x) = def { maxConcurrentStreams = Just x }

--- a/src/Network/HTTP2/Client/Helpers.hs
+++ b/src/Network/HTTP2/Client/Helpers.hs
@@ -57,10 +57,10 @@ ping conn timeout msg = do
 -- | Result containing the unpacked headers and all frames received in on a
 -- stream. See 'StreamResponse' and 'fromStreamResult' to get a higher-level
 -- utility.
-type StreamResult = (Either HTTP2.ErrorCode HPACK.HeaderList, [Either HTTP2.ErrorCode ByteString], Maybe HPACK.HeaderList)
+type StreamResult = (Either HTTP2.ErrorCode [HPACK.Header], [Either HTTP2.ErrorCode ByteString], Maybe [HPACK.Header])
 
 -- | An HTTP2 response, once fully received, is made of headers and a payload.
-type StreamResponse = (HPACK.HeaderList, ByteString, Maybe HPACK.HeaderList)
+type StreamResponse = ([HPACK.Header], ByteString, Maybe [HPACK.Header])
 
 -- | Uploads a whole HTTP body at a time.
 --


### PR DESCRIPTION
`HeaderList` was replaced with `[Header]`, `SettingsHeaderTableSize` was replaced with `SettingsTokenHeaderTableSize`.

Closes #94